### PR TITLE
Cb refactor to interfaces

### DIFF
--- a/src/calendar/timeslice.ts
+++ b/src/calendar/timeslice.ts
@@ -93,6 +93,52 @@ export class TimeSlice{
         return this._momentList.find(m => m.overlaps(selection as Moment))
     }
 
+    getCorrespondingRange(selection : IPeriod | Moment ) : ITimeSlice {
+        if("to" in selection){
+            selection = new Moment(selection);
+        }
+
+        return new CorrespondingRange(this._momentList.filter(x => x.overlaps(selection as IMoment)));
+    }
+}
+
+class CorrespondingRange {
+    private _momentList : Array<IMoment>;
+    constructor(list : Array<IMoment>){
+        this._momentList = list;
+    }
+    get length () : number{
+        return this._momentList.length;
+    }
+
+    get(index : number) : IMoment{
+        if(index < 0 || index > this.length -1)
+            throw new RangeError();
+        return this._momentList[index];
+    }
+
+    get first() : IMoment{
+        return this._momentList[0];
+    }
+
+    get last() : IMoment{
+        return this._momentList[this.length-1]
+    }
+
+    getCorresponding(selection : Date | IMoment | IInstant) : IMoment | undefined{
+
+        if("startsAt" in selection)
+            selection.type == MomentType.Duration ? selection = new Moment(selection.startsAt) : selection;
+        else{
+            selection = new Moment(selection);
+        }
+
+        if (selection.before(this.first) || selection.after(this.last))
+            return undefined;    
+
+        return this._momentList.find(m => m.overlaps(selection as Moment))
+    }
+
     getCorrespondingRange(selection : IPeriod | Moment ) : Array<IMoment> {
         if("to" in selection){
             selection = new Moment(selection);

--- a/src/tests/timesliceTS/timeslice.getCorrespondingRange.spec.ts
+++ b/src/tests/timesliceTS/timeslice.getCorrespondingRange.spec.ts
@@ -13,9 +13,9 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testPeriod);
 
         expect(resultRange.length).toBe(3);
-        expect(resultRange[0].startsAt).toEqual(startDate);
-        expect(resultRange[1].startsAt).toEqual(addDays(startDate, 8));
-        expect(resultRange[2].startsAt).toEqual(addDays(startDate, 15));
+        expect(resultRange.get(0).startsAt).toEqual(startDate);
+        expect(resultRange.get(1).startsAt).toEqual(addDays(startDate, 8));
+        expect(resultRange.get(2).startsAt).toEqual(addDays(startDate, 15));
     })
 
     test("GIVEN a duration within timeslice WHEN getCorrespondingRange THEN returns overlapping moments", ()=>{
@@ -25,9 +25,9 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testMoment);
 
         expect(resultRange.length).toBe(3);
-        expect(resultRange[0].startsAt).toEqual(startDate);
-        expect(resultRange[1].startsAt).toEqual(addDays(startDate, 8));
-        expect(resultRange[2].startsAt).toEqual(addDays(startDate, 15));
+        expect(resultRange.get(0).startsAt).toEqual(startDate);
+        expect(resultRange.get(1).startsAt).toEqual(addDays(startDate, 8));
+        expect(resultRange.get(2).startsAt).toEqual(addDays(startDate, 15));
     })
 
     test("GIVEN a timestamp within timeslice WHEN getCorrespondingRange THEN returns overlapping moments", ()=>{
@@ -37,7 +37,7 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testMoment);
 
         expect(resultRange.length).toBe(1);
-        expect(resultRange[0].startsAt).toEqual(addDays(startDate, 8));
+        expect(resultRange.get(0).startsAt).toEqual(addDays(startDate, 8));
     })
 
     test("GIVEN a period overlapping at start WHEN getCorrespondingRange THEN returns overlapping moments", ()=>{
@@ -47,9 +47,9 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testPeriod);
 
         expect(resultRange.length).toBe(3);
-        expect(resultRange[0].startsAt).toEqual(startDate);
-        expect(resultRange[1].startsAt).toEqual(addDays(startDate, 8));
-        expect(resultRange[2].startsAt).toEqual(addDays(startDate, 15));
+        expect(resultRange.get(0).startsAt).toEqual(startDate);
+        expect(resultRange.get(1).startsAt).toEqual(addDays(startDate, 8));
+        expect(resultRange.get(2).startsAt).toEqual(addDays(startDate, 15));
     })
 
     test("GIVEN a duration overlapping at start WHEN getCorrespondingRange THEN returns overlapping moments", ()=>{
@@ -59,9 +59,9 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testPeriod);
 
         expect(resultRange.length).toBe(3);
-        expect(resultRange[0].startsAt).toEqual(startDate);
-        expect(resultRange[1].startsAt).toEqual(addDays(startDate, 8));
-        expect(resultRange[2].startsAt).toEqual(addDays(startDate, 15));
+        expect(resultRange.get(0).startsAt).toEqual(startDate);
+        expect(resultRange.get(1).startsAt).toEqual(addDays(startDate, 8));
+        expect(resultRange.get(2).startsAt).toEqual(addDays(startDate, 15));
     })
 
     test("GIVEN a period that overlaps end WHEN getCorrespondingRange THEN returns overlapping moments", () =>{
@@ -71,7 +71,7 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testPeriod);
 
         expect(resultRange.length).toBe(1);
-        expect(resultRange[0].startsAt).toEqual(addDays(startDate, 22));
+        expect(resultRange.get(0).startsAt).toEqual(addDays(startDate, 22));
     })
 
     test("GIVEN a duration that overlaps end WHEN getCorrespondingRange THEN returns overlapping moments", () =>{
@@ -81,7 +81,7 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testMoment);
 
         expect(resultRange.length).toBe(1);
-        expect(resultRange[0].startsAt).toEqual(addDays(startDate, 22));
+        expect(resultRange.get(0).startsAt).toEqual(addDays(startDate, 22));
     })
     test("GIVEN a timestamp that overlaps end WHEN getCorrespondingRange THEN returns overlapping moments", () =>{
         let slice =  createSampleMonthTimeSlice();
@@ -90,7 +90,7 @@ describe("tests for get corresponding range", () =>{
         let resultRange = slice.getCorrespondingRange(testMoment);
 
         expect(resultRange.length).toBe(1);
-        expect(resultRange[0].startsAt).toEqual(addDays(startDate, 22));
+        expect(resultRange.get(0).startsAt).toEqual(addDays(startDate, 22));
     })
 
     test("GIVEN a period before close WHEN getCorrespondingRange THEN returns empty list",() =>{


### PR DESCRIPTION
have changed time splice.getCorrespondingRange to return an ITimeslice special implementation thus maintaining Immutability. 