### PR TITLE
Fixed consistency bug with TimeSlice

### DIFF
--- a/src/calendar/timeslice.ts
+++ b/src/calendar/timeslice.ts
@@ -8,7 +8,7 @@ export interface ITimeSlice{
     get first() : IMoment;
     get last() : IMoment;
     getCorresponding(selection : Date | IMoment | IInstant) : IMoment | undefined;
-    getCorrespondingRange(selection : IPeriod | Moment ) : Array<IMoment>
+    getCorrespondingRange(selection : IPeriod | Moment ) : ITimeSlice
 }
 
 
@@ -139,11 +139,11 @@ class CorrespondingRange {
         return this._momentList.find(m => m.overlaps(selection as Moment))
     }
 
-    getCorrespondingRange(selection : IPeriod | Moment ) : Array<IMoment> {
+    getCorrespondingRange(selection : IPeriod | Moment ) : ITimeSlice {
         if("to" in selection){
             selection = new Moment(selection);
         }
 
-        return this._momentList.filter(x => x.overlaps(selection as IMoment));
+        return new CorrespondingRange(this._momentList.filter(x => x.overlaps(selection as IMoment)));
     }
 }


### PR DESCRIPTION
last change introduced a consistency issue
1 - Interface ITimeSlicee now has correct signature for GetPCorrespondingRange 
2 - CorrespondingRange private class now matches the intended interface 